### PR TITLE
feat: allow panels to opt out of route registration via hasRoutes()

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -12,23 +12,26 @@ Route::name('wirechat.')
             return;
         }
         foreach ($panels as $panel) {
-            Route::prefix($panel->getRoutePrefix())
-                ->name("{$panel->getPath()}.")
-                ->middleware(array_merge(
-                    ['web'],
-                    $panel->getMiddleware(),
-                    [
-                        "wirechat.setPanel:{$panel->getId()}",
-                        "wirechat.panelAccess:{$panel->getId()}",
-                    ]
-                ))
-                ->group(function () use ($panel) {
-                    Route::view('/', 'wirechat::pages.chats', ['panel' => $panel->getId()])
-                        ->name('chats');
-                    Route::view('/{conversation}', 'wirechat::pages.chat', ['panel' => $panel->getId()])
-                        ->middleware($panel->getChatMiddleware())
-                        ->name('chat');
+            /* Register routes only if enabled */
+            if ($panel->hasRoutes()) {
+                Route::prefix($panel->getRoutePrefix())
+                    ->name("{$panel->getPath()}.")
+                    ->middleware(array_merge(
+                        ['web'],
+                        $panel->getMiddleware(),
+                        [
+                            "wirechat.setPanel:{$panel->getId()}",
+                            "wirechat.panelAccess:{$panel->getId()}",
+                        ]
+                    ))
+                    ->group(function () use ($panel) {
+                        Route::view('/', 'wirechat::pages.chats', ['panel' => $panel->getId()])
+                            ->name('chats');
+                        Route::view('/{conversation}', 'wirechat::pages.chat', ['panel' => $panel->getId()])
+                            ->middleware($panel->getChatMiddleware())
+                            ->name('chat');
 
-                });
+                    });
+            }
         }
     });

--- a/src/Panel/Concerns/HasRoutes.php
+++ b/src/Panel/Concerns/HasRoutes.php
@@ -17,6 +17,8 @@ trait HasRoutes
      */
     protected array $routes = [];
 
+    protected bool|Closure $hasRoutes = true;
+
     /**
      * The home URL for the panel, which can be a string, Closure, or null.
      */
@@ -40,6 +42,24 @@ trait HasRoutes
      * @const string
      */
     public const CHAT_ROUTE_NAME = 'chat';
+
+    /**
+     * Check if panel has registered routes
+     */
+    public function hasRoutes(): bool
+    {
+        return (bool) $this->evaluate($this->hasRoutes);
+    }
+
+    /**
+     * @param bool|\Closure $condition
+     */
+    public function registerRoutes(bool|Closure $condition = true): static
+    {
+        $this->hasRoutes = $condition;
+
+        return $this;
+    }
 
     /**
      * Sets the home URL for the panel.

--- a/src/Panel/Concerns/HasRoutes.php
+++ b/src/Panel/Concerns/HasRoutes.php
@@ -51,9 +51,6 @@ trait HasRoutes
         return (bool) $this->evaluate($this->hasRoutes);
     }
 
-    /**
-     * @param bool|\Closure $condition
-     */
     public function registerRoutes(bool|Closure $condition = true): static
     {
         $this->hasRoutes = $condition;

--- a/tests/Unit/PanelTest.php
+++ b/tests/Unit/PanelTest.php
@@ -2,6 +2,22 @@
 
 use Workbench\App\Models\User;
 
+test(' panel hasRoutes is true by default()', function () {
+    $auth = User::factory()->create();
+
+    expect(testPanelProvider()->hasRoutes())->toBeTrue();
+
+});
+
+test(' panel hasRoutes is false when registerRoutes is FALSE', function () {
+    $auth = User::factory()->create();
+
+    testPanelProvider()->registerRoutes(false);
+
+    expect(testPanelProvider()->hasRoutes())->toBeFalse();
+
+});
+
 describe('Chats Route', function () {
 
     test('return 404 if user canAccessWirechatPanel() returns false on chats route', function () {


### PR DESCRIPTION

 This PR adds a `registerRoutes(bool|Closure $condition = true)` API on the `Panel` class.

Panels now expose a `hasRoutes()` flag, and the web routes are only registered when this flag is `true`.
This allows consumers to programmatically enable/disable route registration per panel (e.g. based on config, environment, or a closure), and keeps unused panels from registering routes unnecessarily.
