### PR TITLE
fix: treat non-image and non-video attachments as files

### DIFF
--- a/resources/views/livewire/chat/partials/body.blade.php
+++ b/resources/views/livewire/chat/partials/body.blade.php
@@ -277,19 +277,17 @@
                                                 {{ $message->sendable?->wirechat_name }}
                                             </div>
                                         @endif
-                                        {{-- Attachemnt is Application/ --}}
-                                        @if (str()->startsWith($attachment->mime_type, 'application/'))
-                                            @include('wirechat::livewire.chat.partials.file', [ 'attachment' => $attachment ])
-                                        @endif
 
-                                        {{-- Attachemnt is Video/ --}}
                                         @if (str()->startsWith($attachment->mime_type, 'video/'))
+                                        {{-- Attachemnt is Video/ --}}
                                             <x-wirechat::video height="max-h-[400px]" :cover="false" source="{{ $attachment?->url }}" />
-                                        @endif
 
+                                        @elseif (str()->startsWith($attachment->mime_type, 'image/'))
                                         {{-- Attachemnt is image/ --}}
-                                        @if (str()->startsWith($attachment->mime_type, 'image/'))
                                             @include('wirechat::livewire.chat.partials.image', [ 'previousMessage' => $previousMessage, 'message' => $message, 'nextMessage' => $nextMessage, 'belongsToAuth' => $belongsToAuth, 'attachment' => $attachment ])
+                                        @else
+                                        {{-- Attachemnt is Application/ --}}
+                                           @include('wirechat::livewire.chat.partials.file', [ 'attachment' => $attachment ])
                                         @endif
                                     @endif
 


### PR DESCRIPTION
Simplifies attachment rendering by treating all non-image and non-video MIME types as files.
This fixes missing previews for text-based and other application attachments without relying on MIME guessing.